### PR TITLE
feat: add filtering and sorting for invoices list (#19)

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1633,3 +1633,314 @@ td a {
     }
   }
 }
+
+// =============================================================================
+// Filter Bar
+// =============================================================================
+.filter-bar {
+  background-color: $color-surface;
+  border: 1px solid $color-border;
+  border-radius: $radius-md;
+  margin-bottom: $spacing-6;
+  overflow: hidden;
+}
+
+.filter-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: $spacing-3 $spacing-4;
+  background-color: $color-bg;
+  border-bottom: 1px solid $color-border;
+}
+
+.filter-toggle {
+  display: flex;
+  align-items: center;
+  gap: $spacing-2;
+  padding: 0;
+  background-color: transparent;
+  border: none;
+  font-size: $font-size-sm;
+  font-weight: $font-weight-medium;
+  color: $color-text;
+  cursor: pointer;
+
+  .filter-chevron {
+    transition: transform $transition-base;
+    color: $color-text-muted;
+
+    &.expanded {
+      transform: rotate(180deg);
+    }
+  }
+}
+
+.active-filters-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 $spacing-1;
+  background-color: var(--color-primary);
+  color: $color-primary-text;
+  font-size: 11px;
+  font-weight: $font-weight-semibold;
+  border-radius: $radius-full;
+}
+
+.filter-panel {
+  display: none;
+  padding: $spacing-4;
+
+  &.expanded {
+    display: block;
+  }
+}
+
+.filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: $spacing-4;
+  padding-bottom: $spacing-4;
+  border-bottom: 1px solid $color-border;
+
+  &:last-child {
+    padding-bottom: 0;
+    border-bottom: none;
+  }
+}
+
+.filter-row-controls {
+  padding-top: $spacing-4;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+  min-width: 150px;
+}
+
+.filter-group-type {
+  flex-shrink: 0;
+}
+
+.filter-group-status {
+  flex: 1;
+}
+
+.filter-group-date {
+  flex: 1;
+  min-width: 280px;
+}
+
+.filter-doc-toggle {
+  margin: 0;
+}
+
+.filter-label {
+  font-size: $font-size-xs;
+  font-weight: $font-weight-semibold;
+  color: $color-text-muted;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.filter-select {
+  padding: $spacing-2 $spacing-3;
+  font-size: $font-size-sm;
+  border: 1px solid $color-border;
+  border-radius: $radius-base;
+  background-color: $color-surface;
+  color: $color-text;
+  cursor: pointer;
+  transition:
+    border-color $transition-fast,
+    box-shadow $transition-fast;
+
+  &:hover {
+    border-color: var(--color-primary);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 2px var(--color-primary-light);
+  }
+}
+
+.filter-input {
+  padding: $spacing-2 $spacing-3;
+  font-size: $font-size-sm;
+  border: 1px solid $color-border;
+  border-radius: $radius-base;
+  background-color: $color-surface;
+  color: $color-text;
+  transition:
+    border-color $transition-fast,
+    box-shadow $transition-fast;
+
+  &:hover {
+    border-color: var(--color-primary);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 2px var(--color-primary-light);
+  }
+}
+
+.status-checkboxes {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: $spacing-1;
+}
+
+.checkbox-label {
+  cursor: pointer;
+
+  input[type='checkbox'] {
+    display: none;
+  }
+
+  .status-chip {
+    display: inline-block;
+    padding: 4px $spacing-2;
+    font-size: $font-size-xs;
+    font-weight: $font-weight-medium;
+    border-radius: $radius-full;
+    border: 1px solid transparent;
+    transition: all $transition-fast;
+    opacity: 0.5;
+
+    &:hover {
+      opacity: 0.8;
+    }
+  }
+
+  input[type='checkbox']:checked + .status-chip {
+    opacity: 1;
+    border-color: currentColor;
+  }
+}
+
+.date-range-inputs {
+  display: flex;
+  align-items: center;
+  gap: $spacing-2;
+
+  .filter-select {
+    width: auto;
+    min-width: 100px;
+  }
+
+  .filter-input {
+    width: 130px;
+  }
+}
+
+.sort-controls {
+  display: flex;
+  gap: $spacing-2;
+
+  .filter-select {
+    min-width: 120px;
+  }
+}
+
+.btn-sort {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: $spacing-2;
+  min-width: 36px;
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.btn-clear-filters {
+  background-color: transparent;
+  border-color: $color-text-muted;
+  color: $color-text-muted;
+  font-size: $font-size-xs;
+
+  &:hover {
+    border-color: $color-error;
+    color: $color-error;
+    background-color: $color-error-bg;
+  }
+}
+
+// Mobile responsive
+@media (max-width: $breakpoint-md) {
+  .filter-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .filter-group {
+    min-width: 100%;
+  }
+
+  .filter-group-date {
+    min-width: 100%;
+  }
+
+  .date-range-inputs {
+    flex-direction: column;
+    align-items: stretch;
+
+    .filter-select,
+    .filter-input {
+      width: 100%;
+    }
+  }
+
+  .status-checkboxes {
+    gap: $spacing-2;
+  }
+}
+
+// =============================================================================
+// Sortable Table Headers
+// =============================================================================
+.sortable-header {
+  cursor: pointer;
+  user-select: none;
+  transition: background-color $transition-fast;
+
+  &:hover {
+    background-color: $color-border-light;
+  }
+}
+
+.sort-indicator {
+  font-weight: $font-weight-bold;
+  color: var(--color-primary);
+}
+
+// =============================================================================
+// Additional Quote Status Colors
+// =============================================================================
+.status-accepted {
+  background-color: $color-success-bg;
+  color: $color-success-text;
+}
+
+.status-declined {
+  background-color: $color-error-bg;
+  color: $color-error-text;
+}
+
+.status-expired {
+  background-color: $color-warning-bg;
+  color: $color-warning-text;
+}

--- a/src/components/InvoiceFilterBar.tsx
+++ b/src/components/InvoiceFilterBar.tsx
@@ -1,0 +1,236 @@
+import type { ReactElement } from 'react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type {
+  Client,
+  InvoiceStatus,
+  QuoteStatus,
+  DocumentType,
+} from '../types';
+import type {
+  InvoiceFilters,
+  DateRangeField,
+} from '../hooks/useInvoiceFilters';
+
+const INVOICE_STATUSES: InvoiceStatus[] = [
+  'draft',
+  'sent',
+  'paid',
+  'overdue',
+  'cancelled',
+];
+
+const QUOTE_STATUSES: QuoteStatus[] = [
+  'draft',
+  'sent',
+  'accepted',
+  'declined',
+  'expired',
+];
+
+interface InvoiceFilterBarProps {
+  filters: InvoiceFilters;
+  activeFilterCount: number;
+  clients: Client[];
+  onDocumentTypeChange: (type: 'all' | DocumentType) => void;
+  onStatusToggle: (status: InvoiceStatus | QuoteStatus) => void;
+  onClientChange: (clientId: number | null) => void;
+  onDateRangeFieldChange: (field: DateRangeField) => void;
+  onDateFromChange: (date: string | null) => void;
+  onDateToChange: (date: string | null) => void;
+  onClearFilters: () => void;
+}
+
+export function InvoiceFilterBar({
+  filters,
+  activeFilterCount,
+  clients,
+  onDocumentTypeChange,
+  onStatusToggle,
+  onClientChange,
+  onDateRangeFieldChange,
+  onDateFromChange,
+  onDateToChange,
+  onClearFilters,
+}: InvoiceFilterBarProps): ReactElement {
+  const { t } = useTranslation();
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const getAvailableStatuses = (): Array<InvoiceStatus | QuoteStatus> => {
+    if (filters.documentType === 'invoice') {
+      return INVOICE_STATUSES;
+    }
+    if (filters.documentType === 'quote') {
+      return QUOTE_STATUSES;
+    }
+    const uniqueStatuses = new Set([...INVOICE_STATUSES, ...QUOTE_STATUSES]);
+    return Array.from(uniqueStatuses);
+  };
+
+  const availableStatuses = getAvailableStatuses();
+
+  return (
+    <div className="filter-bar">
+      {/* Header with toggle and clear button */}
+      <div className="filter-header">
+        <button
+          type="button"
+          className="filter-toggle"
+          onClick={() => setIsExpanded(!isExpanded)}
+          aria-expanded={isExpanded}
+        >
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+          </svg>
+          <span>{t('filters.show')}</span>
+          {activeFilterCount > 0 && (
+            <span className="active-filters-badge">{activeFilterCount}</span>
+          )}
+          <svg
+            className={`filter-chevron ${isExpanded ? 'expanded' : ''}`}
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </button>
+
+        {activeFilterCount > 0 && (
+          <button
+            type="button"
+            className="btn btn-sm btn-clear-filters"
+            onClick={onClearFilters}
+          >
+            {t('filters.clear')}
+          </button>
+        )}
+      </div>
+
+      {/* Filter panel */}
+      <div className={`filter-panel ${isExpanded ? 'expanded' : ''}`}>
+        {/* Row 1: Document Type and Status */}
+        <div className="filter-row">
+          <div className="filter-group filter-group-type">
+            <div className="document-type-toggle filter-doc-toggle">
+              <label className="toggle-label">
+                <input
+                  type="radio"
+                  name="documentType"
+                  value="all"
+                  checked={filters.documentType === 'all'}
+                  onChange={() => onDocumentTypeChange('all')}
+                />
+                <span className="toggle-option">{t('documents.all')}</span>
+              </label>
+              <label className="toggle-label">
+                <input
+                  type="radio"
+                  name="documentType"
+                  value="invoice"
+                  checked={filters.documentType === 'invoice'}
+                  onChange={() => onDocumentTypeChange('invoice')}
+                />
+                <span className="toggle-option">{t('documents.invoice')}</span>
+              </label>
+              <label className="toggle-label">
+                <input
+                  type="radio"
+                  name="documentType"
+                  value="quote"
+                  checked={filters.documentType === 'quote'}
+                  onChange={() => onDocumentTypeChange('quote')}
+                />
+                <span className="toggle-option">{t('documents.quote')}</span>
+              </label>
+            </div>
+          </div>
+
+          <div className="filter-group filter-group-status">
+            <div className="status-checkboxes">
+              {availableStatuses.map((status) => (
+                <label key={status} className="checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={filters.statuses.includes(status)}
+                    onChange={() => onStatusToggle(status)}
+                  />
+                  <span className={`status-chip status-${status}`}>
+                    {t(`invoices.status.${status}`)}
+                  </span>
+                </label>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Row 2: Client and Date Range */}
+        <div className="filter-row filter-row-controls">
+          <div className="filter-group">
+            <label className="filter-label">{t('filters.client.label')}</label>
+            <select
+              value={filters.clientId ?? ''}
+              onChange={(e) =>
+                onClientChange(e.target.value ? Number(e.target.value) : null)
+              }
+              className="filter-select"
+            >
+              <option value="">{t('filters.client.all')}</option>
+              {clients.map((client) => (
+                <option key={client.id} value={client.id}>
+                  {client.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="filter-group filter-group-date">
+            <label className="filter-label">
+              {t('filters.dateRange.label')}
+            </label>
+            <div className="date-range-inputs">
+              <select
+                value={filters.dateRange.field}
+                onChange={(e) =>
+                  onDateRangeFieldChange(e.target.value as DateRangeField)
+                }
+                className="filter-select"
+              >
+                <option value="issueDate">
+                  {t('invoices.fields.issueDate')}
+                </option>
+                <option value="dueDate">{t('invoices.fields.dueDate')}</option>
+              </select>
+              <input
+                type="date"
+                value={filters.dateRange.from ?? ''}
+                onChange={(e) => onDateFromChange(e.target.value || null)}
+                className="filter-input"
+              />
+              <input
+                type="date"
+                value={filters.dateRange.to ?? ''}
+                onChange={(e) => onDateToChange(e.target.value || null)}
+                className="filter-input"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useInvoiceFilters.ts
+++ b/src/hooks/useInvoiceFilters.ts
@@ -1,0 +1,236 @@
+import { useState, useCallback, useEffect, useMemo } from 'react';
+import type { InvoiceStatus, QuoteStatus, DocumentType } from '../types';
+
+export type SortField =
+  | 'issueDate'
+  | 'dueDate'
+  | 'total'
+  | 'clientName'
+  | 'invoiceNumber';
+
+export type SortDirection = 'asc' | 'desc';
+
+export type DateRangeField = 'issueDate' | 'dueDate';
+
+export interface InvoiceFilters {
+  documentType: 'all' | DocumentType;
+  statuses: Array<InvoiceStatus | QuoteStatus>;
+  clientId: number | null;
+  dateRange: {
+    field: DateRangeField;
+    from: string | null;
+    to: string | null;
+  };
+  amountRange: {
+    min: number | null;
+    max: number | null;
+  };
+}
+
+export interface InvoiceSorting {
+  field: SortField;
+  direction: SortDirection;
+}
+
+export interface InvoiceFiltersState {
+  filters: InvoiceFilters;
+  sorting: InvoiceSorting;
+}
+
+const STORAGE_KEY = 'faturinha-invoice-filters';
+
+const DEFAULT_FILTERS: InvoiceFilters = {
+  documentType: 'all',
+  statuses: [],
+  clientId: null,
+  dateRange: {
+    field: 'issueDate',
+    from: null,
+    to: null,
+  },
+  amountRange: {
+    min: null,
+    max: null,
+  },
+};
+
+const DEFAULT_SORTING: InvoiceSorting = {
+  field: 'issueDate',
+  direction: 'desc',
+};
+
+function loadFromStorage(): InvoiceFiltersState | null {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      return JSON.parse(stored) as InvoiceFiltersState;
+    }
+  } catch {
+    // Ignore parse errors
+  }
+  return null;
+}
+
+function saveToStorage(state: InvoiceFiltersState): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+export interface UseInvoiceFiltersReturn {
+  filters: InvoiceFilters;
+  sorting: InvoiceSorting;
+  activeFilterCount: number;
+  setDocumentType: (type: 'all' | DocumentType) => void;
+  toggleStatus: (status: InvoiceStatus | QuoteStatus) => void;
+  setStatuses: (statuses: Array<InvoiceStatus | QuoteStatus>) => void;
+  setClientId: (clientId: number | null) => void;
+  setDateRangeField: (field: DateRangeField) => void;
+  setDateFrom: (date: string | null) => void;
+  setDateTo: (date: string | null) => void;
+  setAmountMin: (amount: number | null) => void;
+  setAmountMax: (amount: number | null) => void;
+  setSortField: (field: SortField) => void;
+  setSortDirection: (direction: SortDirection) => void;
+  toggleSortDirection: () => void;
+  clearFilters: () => void;
+}
+
+export function useInvoiceFilters(): UseInvoiceFiltersReturn {
+  const [filters, setFilters] = useState<InvoiceFilters>(() => {
+    const stored = loadFromStorage();
+    return stored?.filters ?? DEFAULT_FILTERS;
+  });
+
+  const [sorting, setSorting] = useState<InvoiceSorting>(() => {
+    const stored = loadFromStorage();
+    return stored?.sorting ?? DEFAULT_SORTING;
+  });
+
+  // Persist to localStorage on changes
+  useEffect(() => {
+    saveToStorage({ filters, sorting });
+  }, [filters, sorting]);
+
+  // Calculate active filter count
+  const activeFilterCount = useMemo(() => {
+    let count = 0;
+
+    if (filters.documentType !== 'all') count++;
+    if (filters.statuses.length > 0) count++;
+    if (filters.clientId !== null) count++;
+    if (filters.dateRange.from !== null || filters.dateRange.to !== null)
+      count++;
+    if (filters.amountRange.min !== null || filters.amountRange.max !== null)
+      count++;
+
+    return count;
+  }, [filters]);
+
+  const setDocumentType = useCallback((type: 'all' | DocumentType) => {
+    setFilters((prev) => ({
+      ...prev,
+      documentType: type,
+      // Clear statuses when changing document type to avoid invalid combinations
+      statuses: [],
+    }));
+  }, []);
+
+  const toggleStatus = useCallback((status: InvoiceStatus | QuoteStatus) => {
+    setFilters((prev) => {
+      const isSelected = prev.statuses.includes(status);
+      return {
+        ...prev,
+        statuses: isSelected
+          ? prev.statuses.filter((s) => s !== status)
+          : [...prev.statuses, status],
+      };
+    });
+  }, []);
+
+  const setStatuses = useCallback(
+    (statuses: Array<InvoiceStatus | QuoteStatus>) => {
+      setFilters((prev) => ({ ...prev, statuses }));
+    },
+    []
+  );
+
+  const setClientId = useCallback((clientId: number | null) => {
+    setFilters((prev) => ({ ...prev, clientId }));
+  }, []);
+
+  const setDateRangeField = useCallback((field: DateRangeField) => {
+    setFilters((prev) => ({
+      ...prev,
+      dateRange: { ...prev.dateRange, field },
+    }));
+  }, []);
+
+  const setDateFrom = useCallback((date: string | null) => {
+    setFilters((prev) => ({
+      ...prev,
+      dateRange: { ...prev.dateRange, from: date },
+    }));
+  }, []);
+
+  const setDateTo = useCallback((date: string | null) => {
+    setFilters((prev) => ({
+      ...prev,
+      dateRange: { ...prev.dateRange, to: date },
+    }));
+  }, []);
+
+  const setAmountMin = useCallback((amount: number | null) => {
+    setFilters((prev) => ({
+      ...prev,
+      amountRange: { ...prev.amountRange, min: amount },
+    }));
+  }, []);
+
+  const setAmountMax = useCallback((amount: number | null) => {
+    setFilters((prev) => ({
+      ...prev,
+      amountRange: { ...prev.amountRange, max: amount },
+    }));
+  }, []);
+
+  const setSortField = useCallback((field: SortField) => {
+    setSorting((prev) => ({ ...prev, field }));
+  }, []);
+
+  const setSortDirection = useCallback((direction: SortDirection) => {
+    setSorting((prev) => ({ ...prev, direction }));
+  }, []);
+
+  const toggleSortDirection = useCallback(() => {
+    setSorting((prev) => ({
+      ...prev,
+      direction: prev.direction === 'asc' ? 'desc' : 'asc',
+    }));
+  }, []);
+
+  const clearFilters = useCallback(() => {
+    setFilters(DEFAULT_FILTERS);
+  }, []);
+
+  return {
+    filters,
+    sorting,
+    activeFilterCount,
+    setDocumentType,
+    toggleStatus,
+    setStatuses,
+    setClientId,
+    setDateRangeField,
+    setDateFrom,
+    setDateTo,
+    setAmountMin,
+    setAmountMax,
+    setSortField,
+    setSortDirection,
+    toggleSortDirection,
+    clearFilters,
+  };
+}

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -197,5 +197,29 @@
     "reset": "Testdaten Zurucksetzen",
     "resetConfirm": "Alle Testdaten auf den ursprunglichen Demo-Zustand zurucksetzen?",
     "resetSuccess": "Testdaten wurden zuruckgesetzt"
+  },
+  "filters": {
+    "show": "Filter anzeigen",
+    "hide": "Filter ausblenden",
+    "clear": "Filter loschen",
+    "noResults": "Keine Ergebnisse gefunden",
+    "documentType": "Typ",
+    "status": {
+      "label": "Status"
+    },
+    "client": {
+      "label": "Kunde",
+      "all": "Alle Kunden"
+    },
+    "dateRange": {
+      "label": "Datumsbereich",
+      "from": "Von",
+      "to": "Bis"
+    }
+  },
+  "sorting": {
+    "label": "Sortieren nach",
+    "ascending": "Aufsteigend",
+    "descending": "Absteigend"
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -197,5 +197,29 @@
     "reset": "Reset Test Data",
     "resetConfirm": "Reset all test data to initial demo state?",
     "resetSuccess": "Test data has been reset"
+  },
+  "filters": {
+    "show": "Show Filters",
+    "hide": "Hide Filters",
+    "clear": "Clear Filters",
+    "noResults": "No matching results",
+    "documentType": "Type",
+    "status": {
+      "label": "Status"
+    },
+    "client": {
+      "label": "Client",
+      "all": "All Clients"
+    },
+    "dateRange": {
+      "label": "Date Range",
+      "from": "From",
+      "to": "To"
+    }
+  },
+  "sorting": {
+    "label": "Sort By",
+    "ascending": "Ascending",
+    "descending": "Descending"
   }
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -197,5 +197,29 @@
     "reset": "Reinitialiser les donnees de test",
     "resetConfirm": "Reinitialiser toutes les donnees de test a l'etat initial ?",
     "resetSuccess": "Les donnees de test ont ete reinitialisees"
+  },
+  "filters": {
+    "show": "Afficher les filtres",
+    "hide": "Masquer les filtres",
+    "clear": "Effacer les filtres",
+    "noResults": "Aucun resultat correspondant",
+    "documentType": "Type",
+    "status": {
+      "label": "Statut"
+    },
+    "client": {
+      "label": "Client",
+      "all": "Tous les clients"
+    },
+    "dateRange": {
+      "label": "Periode",
+      "from": "Du",
+      "to": "Au"
+    }
+  },
+  "sorting": {
+    "label": "Trier par",
+    "ascending": "Croissant",
+    "descending": "Decroissant"
   }
 }

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -197,5 +197,29 @@
     "reset": "Ripristina Dati Test",
     "resetConfirm": "Ripristinare tutti i dati test allo stato demo iniziale?",
     "resetSuccess": "I dati test sono stati ripristinati"
+  },
+  "filters": {
+    "show": "Mostra filtri",
+    "hide": "Nascondi filtri",
+    "clear": "Cancella filtri",
+    "noResults": "Nessun risultato corrispondente",
+    "documentType": "Tipo",
+    "status": {
+      "label": "Stato"
+    },
+    "client": {
+      "label": "Cliente",
+      "all": "Tutti i clienti"
+    },
+    "dateRange": {
+      "label": "Intervallo date",
+      "from": "Da",
+      "to": "A"
+    }
+  },
+  "sorting": {
+    "label": "Ordina per",
+    "ascending": "Crescente",
+    "descending": "Decrescente"
   }
 }

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -197,5 +197,29 @@
     "reset": "Testgegevens Resetten",
     "resetConfirm": "Alle testgegevens terugzetten naar de initiiele demo-status?",
     "resetSuccess": "Testgegevens zijn gereset"
+  },
+  "filters": {
+    "show": "Filters tonen",
+    "hide": "Filters verbergen",
+    "clear": "Filters wissen",
+    "noResults": "Geen resultaten gevonden",
+    "documentType": "Type",
+    "status": {
+      "label": "Status"
+    },
+    "client": {
+      "label": "Klant",
+      "all": "Alle klanten"
+    },
+    "dateRange": {
+      "label": "Datumbereik",
+      "from": "Van",
+      "to": "Tot"
+    }
+  },
+  "sorting": {
+    "label": "Sorteren op",
+    "ascending": "Oplopend",
+    "descending": "Aflopend"
   }
 }

--- a/src/i18n/pt-BR.json
+++ b/src/i18n/pt-BR.json
@@ -197,5 +197,29 @@
     "reset": "Resetar Dados de Teste",
     "resetConfirm": "Resetar todos os dados de teste para o estado inicial de demonstracao?",
     "resetSuccess": "Os dados de teste foram resetados"
+  },
+  "filters": {
+    "show": "Mostrar filtros",
+    "hide": "Ocultar filtros",
+    "clear": "Limpar filtros",
+    "noResults": "Nenhum resultado encontrado",
+    "documentType": "Tipo",
+    "status": {
+      "label": "Status"
+    },
+    "client": {
+      "label": "Cliente",
+      "all": "Todos os clientes"
+    },
+    "dateRange": {
+      "label": "Periodo",
+      "from": "De",
+      "to": "Ate"
+    }
+  },
+  "sorting": {
+    "label": "Ordenar por",
+    "ascending": "Crescente",
+    "descending": "Decrescente"
   }
 }

--- a/src/i18n/pt-PT.json
+++ b/src/i18n/pt-PT.json
@@ -197,5 +197,29 @@
     "reset": "Repor Dados de Teste",
     "resetConfirm": "Repor todos os dados de teste para o estado inicial de demonstracao?",
     "resetSuccess": "Os dados de teste foram repostos"
+  },
+  "filters": {
+    "show": "Mostrar filtros",
+    "hide": "Ocultar filtros",
+    "clear": "Limpar filtros",
+    "noResults": "Nenhum resultado encontrado",
+    "documentType": "Tipo",
+    "status": {
+      "label": "Estado"
+    },
+    "client": {
+      "label": "Cliente",
+      "all": "Todos os clientes"
+    },
+    "dateRange": {
+      "label": "Periodo",
+      "from": "De",
+      "to": "Ate"
+    }
+  },
+  "sorting": {
+    "label": "Ordenar por",
+    "ascending": "Crescente",
+    "descending": "Decrescente"
   }
 }

--- a/src/pages/Invoices.tsx
+++ b/src/pages/Invoices.tsx
@@ -1,8 +1,12 @@
 import type { ReactElement } from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { Link } from 'react-router-dom';
 import { useDb } from '../contexts/TestModeContext';
+import { useInvoiceFilters } from '../hooks/useInvoiceFilters';
+import type { SortField } from '../hooks/useInvoiceFilters';
+import { InvoiceFilterBar } from '../components/InvoiceFilterBar';
 import type { Invoice, Client } from '../types';
 
 function formatCurrency(amount: number, currency: string): string {
@@ -24,35 +28,153 @@ export function Invoices(): ReactElement {
   const { t } = useTranslation();
   const db = useDb();
 
-  const invoices = useLiveQuery(
-    () => db.invoices.orderBy('issueDate').reverse().toArray(),
-    [db]
-  );
+  const {
+    filters,
+    sorting,
+    activeFilterCount,
+    setDocumentType,
+    toggleStatus,
+    setClientId,
+    setDateRangeField,
+    setDateFrom,
+    setDateTo,
+    setSortField,
+    toggleSortDirection,
+    clearFilters,
+  } = useInvoiceFilters();
+
+  // Query invoices, optionally filtering by documentType at DB level
+  const invoices = useLiveQuery(() => {
+    if (filters.documentType === 'all') {
+      return db.invoices.orderBy('issueDate').reverse().toArray();
+    }
+    return db.invoices
+      .where('documentType')
+      .equals(filters.documentType)
+      .reverse()
+      .sortBy('issueDate');
+  }, [db, filters.documentType]);
+
   const clients = useLiveQuery(() => db.clients.toArray(), [db]);
 
-  const clientMap = new Map<number, Client>();
-  clients?.forEach((client) => {
-    if (client.id) clientMap.set(client.id, client);
-  });
+  const clientMap = useMemo(() => {
+    const map = new Map<number, Client>();
+    clients?.forEach((client) => {
+      if (client.id) map.set(client.id, client);
+    });
+    return map;
+  }, [clients]);
 
   const getClientName = (clientId: number): string => {
     return clientMap.get(clientId)?.name ?? 'Unknown';
   };
 
+  // Apply in-memory filters and sorting
+  const filteredAndSortedInvoices = useMemo(() => {
+    if (!invoices) return [];
+
+    let result = [...invoices];
+
+    // Filter by status
+    if (filters.statuses.length > 0) {
+      result = result.filter((inv) => filters.statuses.includes(inv.status));
+    }
+
+    // Filter by client
+    if (filters.clientId !== null) {
+      result = result.filter((inv) => inv.clientId === filters.clientId);
+    }
+
+    // Filter by date range
+    const { field: dateField, from: dateFrom, to: dateTo } = filters.dateRange;
+    if (dateFrom || dateTo) {
+      result = result.filter((inv) => {
+        const dateValue = new Date(inv[dateField]).getTime();
+        if (dateFrom) {
+          const fromTime = new Date(dateFrom).getTime();
+          if (dateValue < fromTime) return false;
+        }
+        if (dateTo) {
+          const toTime = new Date(dateTo).getTime();
+          // Include the entire day by adding 24 hours
+          if (dateValue > toTime + 24 * 60 * 60 * 1000) return false;
+        }
+        return true;
+      });
+    }
+
+    // Filter by amount range
+    const { min: amountMin, max: amountMax } = filters.amountRange;
+    if (amountMin !== null || amountMax !== null) {
+      result = result.filter((inv) => {
+        if (amountMin !== null && inv.total < amountMin) return false;
+        if (amountMax !== null && inv.total > amountMax) return false;
+        return true;
+      });
+    }
+
+    // Sort
+    result.sort((a, b) => {
+      let comparison = 0;
+
+      switch (sorting.field) {
+        case 'issueDate':
+          comparison =
+            new Date(a.issueDate).getTime() - new Date(b.issueDate).getTime();
+          break;
+        case 'dueDate':
+          comparison =
+            new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime();
+          break;
+        case 'total':
+          comparison = a.total - b.total;
+          break;
+        case 'clientName': {
+          const nameA = clientMap.get(a.clientId)?.name ?? 'Unknown';
+          const nameB = clientMap.get(b.clientId)?.name ?? 'Unknown';
+          comparison = nameA.localeCompare(nameB);
+          break;
+        }
+        case 'invoiceNumber':
+          comparison = a.invoiceNumber.localeCompare(b.invoiceNumber);
+          break;
+      }
+
+      return sorting.direction === 'asc' ? comparison : -comparison;
+    });
+
+    return result;
+  }, [invoices, filters, sorting, clientMap]);
+
   const getStatusClass = (status: Invoice['status']): string => {
     const classes: Record<Invoice['status'], string> = {
-      // Invoice statuses
       draft: 'status-draft',
       sent: 'status-sent',
       paid: 'status-paid',
       overdue: 'status-overdue',
       cancelled: 'status-cancelled',
-      // Quote statuses
       accepted: 'status-accepted',
       declined: 'status-declined',
       expired: 'status-expired',
     };
     return classes[status];
+  };
+
+  const handleHeaderClick = (field: SortField): void => {
+    if (sorting.field === field) {
+      toggleSortDirection();
+    } else {
+      setSortField(field);
+    }
+  };
+
+  const renderSortIndicator = (field: SortField): ReactElement | null => {
+    if (sorting.field !== field) return null;
+    return (
+      <span className="sort-indicator">
+        {sorting.direction === 'asc' ? ' \u2191' : ' \u2193'}
+      </span>
+    );
   };
 
   if (!invoices || !clients) {
@@ -68,27 +190,85 @@ export function Invoices(): ReactElement {
         </Link>
       </div>
 
-      {invoices.length === 0 ? (
+      <InvoiceFilterBar
+        filters={filters}
+        activeFilterCount={activeFilterCount}
+        clients={clients}
+        onDocumentTypeChange={setDocumentType}
+        onStatusToggle={toggleStatus}
+        onClientChange={setClientId}
+        onDateRangeFieldChange={setDateRangeField}
+        onDateFromChange={setDateFrom}
+        onDateToChange={setDateTo}
+        onClearFilters={clearFilters}
+      />
+
+      {filteredAndSortedInvoices.length === 0 ? (
         <div className="empty-state">
-          <p>{t('invoices.empty')}</p>
-          <p className="text-muted">{t('invoices.emptyDescription')}</p>
+          {invoices.length === 0 ? (
+            <>
+              <p>{t('invoices.empty')}</p>
+              <p className="text-muted">{t('invoices.emptyDescription')}</p>
+            </>
+          ) : (
+            <>
+              <p>{t('filters.noResults')}</p>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={clearFilters}
+              >
+                {t('filters.clear')}
+              </button>
+            </>
+          )}
         </div>
       ) : (
         <div className="invoices-list">
           <table>
             <thead>
               <tr>
-                <th>{t('invoices.fields.invoiceNumber')}</th>
-                <th>{t('invoices.fields.client')}</th>
-                <th>{t('invoices.fields.issueDate')}</th>
-                <th>{t('invoices.fields.dueDate')}</th>
-                <th>{t('invoices.fields.total')}</th>
+                <th
+                  className="sortable-header"
+                  onClick={() => handleHeaderClick('invoiceNumber')}
+                >
+                  {t('invoices.fields.invoiceNumber')}
+                  {renderSortIndicator('invoiceNumber')}
+                </th>
+                <th
+                  className="sortable-header"
+                  onClick={() => handleHeaderClick('clientName')}
+                >
+                  {t('invoices.fields.client')}
+                  {renderSortIndicator('clientName')}
+                </th>
+                <th
+                  className="sortable-header"
+                  onClick={() => handleHeaderClick('issueDate')}
+                >
+                  {t('invoices.fields.issueDate')}
+                  {renderSortIndicator('issueDate')}
+                </th>
+                <th
+                  className="sortable-header"
+                  onClick={() => handleHeaderClick('dueDate')}
+                >
+                  {t('invoices.fields.dueDate')}
+                  {renderSortIndicator('dueDate')}
+                </th>
+                <th
+                  className="sortable-header"
+                  onClick={() => handleHeaderClick('total')}
+                >
+                  {t('invoices.fields.total')}
+                  {renderSortIndicator('total')}
+                </th>
                 <th>Status</th>
                 <th></th>
               </tr>
             </thead>
             <tbody>
-              {invoices.map((invoice) => (
+              {filteredAndSortedInvoices.map((invoice) => (
                 <tr key={invoice.id}>
                   <td>
                     <Link to={`/invoices/${invoice.id}/view`}>


### PR DESCRIPTION
- Add useInvoiceFilters hook with localStorage persistence
- Add InvoiceFilterBar component with collapsible panel
- Filter by document type (all/invoices/quotes)
- Filter by status with multi-select chips
- Filter by client dropdown
- Filter by date range (issue date or due date)
- Sortable table headers with direction indicators
- Mobile responsive design
- Add translations for all 7 locales