### PR TITLE
fix: resolve flaky e2e tests for theme colors and test mode export

### DIFF
--- a/e2e/data-export.spec.ts
+++ b/e2e/data-export.spec.ts
@@ -248,6 +248,10 @@ test.describe('Data Export in Test Mode', () => {
     await page.click('button:has-text("Enter Test Mode")');
     await page.waitForSelector('.test-mode-banner');
 
+    // Wait for test data to be seeded by checking clients page first
+    await page.goto('/clients');
+    await page.waitForSelector('.clients-list table tbody tr', { timeout: 5000 });
+
     // Go to settings and export
     await page.goto('/settings');
 

--- a/e2e/theme-colors.spec.ts
+++ b/e2e/theme-colors.spec.ts
@@ -1,5 +1,17 @@
 import { test, expect } from '@playwright/test';
 
+// Helper to compare RGB colors with tolerance for browser rounding differences
+function rgbColorsMatch(actual: string, expected: string, tolerance = 2): boolean {
+  const parseRgb = (rgb: string): number[] => {
+    const match = rgb.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+    return match ? [parseInt(match[1]), parseInt(match[2]), parseInt(match[3])] : [];
+  };
+  const actualRgb = parseRgb(actual);
+  const expectedRgb = parseRgb(expected);
+  if (actualRgb.length !== 3 || expectedRgb.length !== 3) return false;
+  return actualRgb.every((val, i) => Math.abs(val - expectedRgb[i]) <= tolerance);
+}
+
 test.describe('Theme Color Customization', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/settings');
@@ -98,8 +110,8 @@ test.describe('Theme Color Customization', () => {
       return getComputedStyle(el).backgroundColor;
     });
 
-    // RGB for #dc2626
-    expect(bgColor).toBe('rgb(220, 38, 38)');
+    // RGB for #dc2626 (with tolerance for browser rounding)
+    expect(rgbColorsMatch(bgColor, 'rgb(220, 38, 38)')).toBe(true);
   });
 
   test('should apply theme color to primary buttons', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Add RGB color comparison helper with tolerance for browser rounding differences
- Wait for test data to be seeded before exporting in test mode

## Test plan
- [x] Run `npx playwright test --project=chromium -g "should apply theme color to navigation active state"` - passes
- [x] Run `npx playwright test --project=chromium -g "should export test mode data separately"` - passes